### PR TITLE
Native m1 builds

### DIFF
--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -143,6 +143,7 @@ jobs:
 
       - name: Rename wheel
         shell: python
+        if: ${{ matrix.arch }} == 'arm64'
         run: |
           import distutils.util
           os_version = distutils.util.get_macosx_target_ver().split('.')[0]

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -209,11 +209,11 @@ jobs:
         with:
           repository: pyrtlsdr/pyrtlsdr
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: MatteoH2O1999/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-
+          cache-build: true
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -141,6 +141,20 @@ jobs:
           PYRTLSDRLIB_PLATFORM: macos
           PYRTLSDRLIB_ARCH: ${{ matrix.arch }}
 
+      - name: Rename wheel
+        shell: python
+        run: |
+          import distutils.util
+          os_version = distutils.util.get_macosx_target_ver().split('.')[0]
+          from pathlib import Path
+          dists = Path('dist')
+          arm_wheels = [p for p in dists.glob('*macosx*arm64.whl')]
+          assert len(arm_wheels) == 1, str(arm_wheels)
+          whl = arm_wheels[0]
+          new_whl = whl.with_name(whl.name.replace(f'{os_version}_0', '11_0'))
+          print(f'{whl} > {new_whl}')
+          whl.rename(new_whl)
+
       - name: Test wheel files
         run: pipenv run py.test tests/test_wheel_files.py
 

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -103,22 +103,11 @@ jobs:
           python -c "import platform;print(platform.uname())"
           python -c "import distutils;print(distutils.util.get_platform())"
           python tools/macos_version.py
-      - name: Get macos info
-        id: macos-info
-        run: |
-          BOTTLE_TAG=$(python tools/macos_version.py)
-          echo "BOTTLE_TAG=${{ matrix.arch }}_${BOTTLE_TAG}"
-          echo "BOTTLE_TAG=${{ matrix.arch }}_${BOTTLE_TAG}" >> $GITHUB_OUTPUT
       - name: Uninstall libusb
         continue-on-error: true
         run: brew uninstall --ignore-dependencies libusb
       - name: Install libusb
-        run: |
-          brew fetch --force --bottle-tag $BOTTLE_TAG libusb
-          export BOTTLE_PATH=$(brew --cache --bottle-tag=$BOTTLE_TAG libusb)
-          brew install $BOTTLE_PATH
-        env:
-          BOTTLE_TAG: ${{ steps.macos-info.outputs.BOTTLE_TAG }}
+        run: brew install libusb
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Rename wheel
         shell: python
-        if: ${{ matrix.arch }} == 'arm64'
+        if: ${{ matrix.arch == 'arm64' }}
         run: |
           import distutils.util
           os_version = distutils.util.get_macosx_target_ver().split('.')[0]

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install pipenv
-          pipenv install --dev
+          pipenv -v install --dev
 
       - name: Build librtlsdr source
         run: pipenv run python tools/get_releases.py --build-types source --macos-arch=$MACOS_ARCH

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Get macos info
         id: macos-info
         run: |
-          BOTTLE_TAG=$(python tools/macos_version.py --force-version ${{ matrix.os }})
+          BOTTLE_TAG=$(python tools/macos_version.py)
           echo "BOTTLE_TAG=${{ matrix.arch }}_${BOTTLE_TAG}"
           echo "BOTTLE_TAG=${{ matrix.arch }}_${BOTTLE_TAG}" >> $GITHUB_OUTPUT
       - name: Uninstall libusb

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -94,11 +94,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: MatteoH2O1999/setup-python@v1
+        uses: MatteoH2O1999/setup-python@v3
         with:
           python-version: '3.10.12'
           cache-build: true
-          cache: 'pipenv'
       - name: Log native platform info
         run: |
           python -c "import platform;print(platform.uname())"
@@ -124,7 +123,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install pipenv
-          pipenv -v install --dev
+          pipenv install --dev
 
       - name: Build librtlsdr source
         run: pipenv run python tools/get_releases.py --build-types source --macos-arch=$MACOS_ARCH

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -202,8 +202,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-11, macos-12, macos-13, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-    # TODO:  Disable this once macos-13 exits "beta"
-    continue-on-error: ${{ matrix.os == 'macos-13' }}
     runs-on:
       ${{ matrix.os }}
     steps:

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -200,7 +200,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, macos-12, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-11, macos-12, macos-13, macos-14, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on:
       ${{ matrix.os }}

--- a/.github/workflows/build-lib.yml
+++ b/.github/workflows/build-lib.yml
@@ -84,8 +84,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12]
-        arch: [x86_64, arm64]
+        include:
+          - os: macos-latest
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
     runs-on:
       ${{ matrix.os }}
     steps:
@@ -96,6 +99,11 @@ jobs:
           python-version: '3.10.12'
           cache-build: true
           cache: 'pipenv'
+      - name: Log native platform info
+        run: |
+          python -c "import platform;print(platform.uname())"
+          python -c "import distutils;print(distutils.util.get_platform())"
+          python tools/macos_version.py
       - name: Get macos info
         id: macos-info
         run: |

--- a/tests/test_custom_build.py
+++ b/tests/test_custom_build.py
@@ -3,7 +3,7 @@ import pytest
 
 from pyrtlsdrlib.lib import get_library_files, load_librtlsdr
 
-from conftest import HAS_CUSTOM_BUILD, IS_CI, MACOS_ARCH
+from conftest import HAS_CUSTOM_BUILD
 
 pytestmark = pytest.mark.skipif(not HAS_CUSTOM_BUILD, reason='No custom build')
 
@@ -15,7 +15,6 @@ def test_custom_build_exists(custom_lib_root):
         lib_files.append(p)
     assert len(lib_files) > 0
 
-@pytest.mark.skipif(IS_CI and MACOS_ARCH=='arm64', reason="arm64 lib won't load on x86_64 runner")
 def test_custom_build_loads(custom_lib_root):
     dll = load_librtlsdr()
     assert dll is not None

--- a/tools/macos_version.py
+++ b/tools/macos_version.py
@@ -5,6 +5,7 @@ VERSION_NAMES = {
     '11': 'big_sur',
     '12': 'monterey',
     '13': 'ventura',
+    '14': 'sonoma',
 }
 
 def get_named_version(version: str) -> str:


### PR DESCRIPTION
Use newly available [M1 macOS runner](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/) for native M1 builds